### PR TITLE
Fix error on test_PBWT_default_haplotypes

### DIFF
--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -29,8 +29,8 @@ class TestPbwtBasics(unittest.TestCase):
                                   'id2_haplotype': [0,0,0]})
         #print(ibd_segs)
         #print(true_segs)
-        self.assertTrue(np.all(ibd_segs.eq(true_segs)))
-    
+        #self.assertTrue(np.all(ibd_segs.eq(true_segs)))
+        self.assertTrue(np.array_equal(ibd_segs,true_segs))
     
     def test_vcf_no_map(self):
         print("\nTesting IBD compute over VCF file with out genetic map...")


### PR DESCRIPTION
test_PBWT_default_haplotypes function was throwing a value error for the use of ".eq" to evaluate equality between test and true output. Changing this to numpy's array_equal fixes the error.