### PR TITLE
enable np.array input

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,7 @@
 
 name: build
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push]
 
 jobs:
   build:

--- a/phasedibd/haplotype_alignment.pyx
+++ b/phasedibd/haplotype_alignment.pyx
@@ -10,19 +10,27 @@ cdef class HaplotypeAlignment:
     Contains test data.
     """
 
-    def __init__(self):
+    def __init__(self, haplotypes=None, chromosomes=None):
          
-        self.chromosomes = ['1']
-        self.current_chromosome = ''
-        self.haplotypes = [[0, 1, 0, 1, 0, 1],
-                           [1, 1, 2, 0, 0, 1],  # 2 represents missing/invalid allele
-                           [1, 1, 1, 1, 1, 1],
-                           [0, 1, 1, 1, 1, 0],
-                           [0, 0, 0, 0, 0, 0],
-                           [1, 0, 0, 0, 1, 0],
-                           [1, 1, 0, 0, 0, 1],
-                           [0, 1, 0, 1, 1, 0]]
+        if haplotypes is None:
+            self.haplotypes = [[0, 1, 0, 1, 0, 1],
+                            [1, 1, 2, 0, 0, 1],  # 2 represents missing/invalid allele
+                            [1, 1, 1, 1, 1, 1],
+                            [0, 1, 1, 1, 1, 0],
+                            [0, 0, 0, 0, 0, 0],
+                            [1, 0, 0, 0, 1, 0],
+                            [1, 1, 0, 0, 0, 1],
+                            [0, 1, 0, 1, 1, 0]]
+        else:
+            self.haplotypes = haplotypes
+        
+        if chromosomes is None:
+            self.chromosomes = ['1']
+        else:
+            self.chromosomes = chromosomes
 
+        self.current_chromosome = ''
+        
         self.num_all_haplotypes = len(self.haplotypes)
         self.num_active_haplotypes = len(self.haplotypes)
         self.num_sites = len(self.haplotypes[0])

--- a/phasedibd/haplotype_alignment.pyx
+++ b/phasedibd/haplotype_alignment.pyx
@@ -10,9 +10,10 @@ cdef class HaplotypeAlignment:
     Contains test data.
     """
 
-    def __init__(self, haplotypes=None, chromosomes=None):
+    def __init__(self, haplotype_array=None, chromosomes=None):
          
-        if haplotypes is None:
+        if haplotype_array is None:
+            # use test data 
             self.haplotypes = [[0, 1, 0, 1, 0, 1],
                             [1, 1, 2, 0, 0, 1],  # 2 represents missing/invalid allele
                             [1, 1, 1, 1, 1, 1],
@@ -22,7 +23,7 @@ cdef class HaplotypeAlignment:
                             [1, 1, 0, 0, 0, 1],
                             [0, 1, 0, 1, 1, 0]]
         else:
-            self.haplotypes = haplotypes
+            self.haplotypes = haplotype_array
         
         if chromosomes is None:
             self.chromosomes = ['1']

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -30,6 +30,35 @@ class TestPbwtBasics(unittest.TestCase):
         #print(ibd_segs)
         #print(true_segs)
         self.assertTrue(np.all(ibd_segs.eq(true_segs)))
+
+    def test_PBWT_default_haplotypes_np_array_input(self):
+        print("\nTesting non-templated PBWT matches over default haplotypes...")
+        haplotype_array = np.array([[0, 1, 0, 1, 0, 1],
+                            [1, 1, 2, 0, 0, 1],  # 2 represents missing/invalid allele
+                            [1, 1, 1, 1, 1, 1],
+                            [0, 1, 1, 1, 1, 0],
+                            [0, 0, 0, 0, 0, 0],
+                            [1, 0, 0, 0, 1, 0],
+                            [1, 1, 0, 0, 0, 1],
+                            [0, 1, 0, 1, 1, 0]])
+
+        haplotypes = ibd.HaplotypeAlignment(haplotype_array=haplotype_array)
+        tpbwt = ibd.TPBWTAnalysis(template=[[1]])
+        ibd_segs = tpbwt.compute_ibd(haplotypes, L_m=3, L_f=0, missing_site_threshold=1, verbose=False)
+        true_segs = pd.DataFrame({'chromosome': ['1'] * 3,
+                                  'start': [0,0,1],
+                                  'end': [3,5,4],
+                                  'start_cm': [0,0,1],
+                                  'end_cm': [3,5,4],
+                                  'start_bp': [0,0,1],
+                                  'end_bp': [3,5,4],
+                                  'id1': [0,1,2],
+                                  'id2': [7,6,3],
+                                  'id1_haplotype': [0,0,0],
+                                  'id2_haplotype': [0,0,0]})
+        #print(ibd_segs)
+        #print(true_segs)
+        self.assertTrue(np.all(ibd_segs.eq(true_segs)))
     
     
     def test_vcf_no_map(self):


### PR DESCRIPTION
Will resolve #6. 

This PR describes a minor modification to phasedIDBs `HaplotypeAlignment` class which allows it to take a numpy array as input through a `haplotype_array` argument. If no haplotype_array is supplied, it defaults back to using the test haplotypes. 